### PR TITLE
use new metaclass syntax in Python 3k

### DIFF
--- a/ariblib/syntax.py
+++ b/ariblib/syntax.py
@@ -57,8 +57,7 @@ class SyntaxType(type):
         return instance
 
 
-class Syntax:
-    __metaclass__ = SyntaxType
+class Syntax(metaclass=SyntaxType):
 
     """シンタックスの親クラス"""
 


### PR DESCRIPTION
#10 でご指摘をいただき修正いたしました metaclass の syntax 修正ですが、 #11 に該当のコミットを含める事を忘たまま #11 をマージして頂いてしまいました。

このプルリクエストはこの問題を修正するものです。

お手数をお掛けして申し訳ありません。
