### PR TITLE
Fix "RuntimeError: generator raised StopIteration"

### DIFF
--- a/ariblib/packet.py
+++ b/ariblib/packet.py
@@ -48,7 +48,7 @@ class TransportStreamFile(BufferedReader):
             ):
                 next = packet[start:stop]
                 if not next:
-                    raise StopIteration
+                    return
                 yield next
 
     def __next__(self):


### PR DESCRIPTION
Fix #14.

Since Python 3.7, raising StopIteration within a generator
causes RuntimeError. This breaking behaviour was introduced
by PEP-479:

> https://peps.python.org/pep-0479/

For this reason, TransportStreamFile iterator always ends
up causing an unhandled exception. Fix it by replacing
`raise StopIteration` with a simple return statement.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>